### PR TITLE
[Rahul] | BAH-3005 | Add. tzdata Package Installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,9 +35,8 @@ RUN apk add --no-cache --virtual .build-deps \
 		py-pip \
 		tar \
         python3-dev \
-        libffi-dev
-
-RUN apk add tzdata
+        libffi-dev \
+		tzdata
 
 RUN python3 -m venv /opt/certbot/ &&\
         /opt/certbot/bin/pip install certbot &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ RUN cd /etc/ &&\
     cd tls &&\
     openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=localhost" -keyout key.pem  -out cert.pem
 
-
 RUN apk add --no-cache --virtual .build-deps \
 		apr-dev \
 		apr-util-dev \
@@ -37,6 +36,8 @@ RUN apk add --no-cache --virtual .build-deps \
 		tar \
         python3-dev \
         libffi-dev
+
+RUN apk add tzdata
 
 RUN python3 -m venv /opt/certbot/ &&\
         /opt/certbot/bin/pip install certbot &&\


### PR DESCRIPTION
Jira Card -> https://bahmni.atlassian.net/browse/BAH-3005

As part of card BAH-3005, it was noticed that all docker containers use UTC as their default timezone and to fix this we have added a TZ environment variable to https://github.com/Bahmni/bahmni-docker/pull/45. In our PAT call (Wed, 24 May 2023) it was decided that we we will install the `tzdata` package in proxy Dockerfile so as to make use of TZ environment variable to configure the timezone for the bahmni-proxy container.