### PR TITLE
BAH-3203 | Fix. Remove default files from cgi-bin directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ COPY resources/internalError.html /usr/local/apache2/htdocs/internalError.html
 COPY resources/style.css /usr/local/apache2/htdocs/style.css
 COPY resources/src.jpeg /usr/local/apache2/htdocs/src.jpeg
 RUN mkdir /var/cache/mod_proxy
+RUN rm -rf /usr/local/apache2/cgi-bin/test-cgi
+RUN rm -rf /usr/local/apache2/cgi-bin/printenv*
 	
 RUN apk add --update openssl && \
     rm -rf /var/cache/apk/*


### PR DESCRIPTION
This PR removes the default cgi-bin directory files to avoid printenv , test-cgi files being rendered. 
JIRA --> https://bahmni.atlassian.net/browse/BAH-3203

Ref: https://www.tenable.com/plugins/nessus/10188
