### PR TITLE
BAH-3528 | Add. Proxy Rules For uploaded-files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN mkdir -p /var/log/client-side-logs/ &&\
 	chmod 777 /var/log/client-side-logs/client-side.log &&\
 	ln -s /usr/local/apache2/htdocs/client_side_logging /usr/lib/python3*/site-packages/ 
 
-RUN pip install Flask pyyaml==6.0.1 mod_wsgi
+RUN pip install Flask pyyaml==6.0.1 mod_wsgi --break-system-packages
 
 # Rename and move mod_wsgi module to apache2 modules
 RUN mv /usr/lib/python*/site-packages/mod_wsgi/server/mod_wsgi-*.so /usr/local/apache2/modules/mod_wsgi.so

--- a/resources/bahmni-proxy.conf
+++ b/resources/bahmni-proxy.conf
@@ -5,6 +5,10 @@ LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so
 
 Redirect permanent /home /bahmni/home/
 
+#Uploaded Files
+ProxyPass /uploaded-files http://patient-documents:80/uploaded-files
+ProxyPassReverse /uploaded-files http://patient-documents:80/uploaded-files
+
 #Patient Documents
 ProxyPass /document_images http://patient-documents:80/document_images
 ProxyPassReverse /document_images http://patient-documents:80/document_images


### PR DESCRIPTION
JIRA -> [BAH-3528](https://bahmni.atlassian.net/browse/BAH-3528)

This PR includes the following changes:

Added proxy rules for the uploaded-files subfolder.
Updated the pip install command in the Dockerfile to force install the requested package and its dependencies, overriding PEP 668. PEP 668 warns against mixing apk-provided packages and pip-provided packages during installation. This fix is temporary, and a card has been added to investigate and resolve the underlying issue later. [Read more](https://stackoverflow.com/a/75696359)