### PR TITLE
BAH-4095 | Refactor. Proxy pass rules to restrict access on bahmni_config path

### DIFF
--- a/resources/bahmni-proxy.conf
+++ b/resources/bahmni-proxy.conf
@@ -45,8 +45,11 @@ Header set X-Robots-Tag "noindex, nofollow"
 ProxyPass /person-management http://bahmni-web:8091/person-management
 ProxyPassReverse /person-management http://bahmni-web:8091/person-management
 
-ProxyPass /bahmni_config http://bahmni-web:8091/bahmni_config
-ProxyPassReverse /bahmni_config http://bahmni-web:8091/bahmni_config
+ProxyPass /bahmni_config/openmrs/apps http://bahmni-web:8091/bahmni_config/openmrs/apps
+ProxyPassReverse /bahmni_config/openmrs/apps http://bahmni-web:8091/bahmni_config/openmrs/apps
+
+ProxyPass /bahmni_config/openmrs/i18n http://bahmni-web:8091/bahmni_config/openmrs/i18n
+ProxyPassReverse /bahmni_config/openmrs/i18n http://bahmni-web:8091/bahmni_config/openmrs/i18n
 
 #Implementer Interface
 ProxyPass /implementer-interface http://implementer-interface/implementer-interface


### PR DESCRIPTION
This PR makes the Proxy forwarding rules stricter for bahmni_config by restricting access to only `/openmrs/apps` and /openmrs/i18n` directories in the bahmni_config virtual directory.

Before:
<img width="1779" alt="image" src="https://github.com/user-attachments/assets/5adff9ca-0030-4997-b1f6-b0cb931b4851">

After:
<img width="1790" alt="image" src="https://github.com/user-attachments/assets/097cc87c-eaa1-4154-98f8-c1db7cc34bd8">
