### PR TITLE
BAH-4353 | Add. DCM4CHEE 5 route as a proxy path

### DIFF
--- a/resources/bahmni-proxy.conf
+++ b/resources/bahmni-proxy.conf
@@ -67,6 +67,10 @@ ProxyPassReverse /bahmnireports http://reports:8051/bahmnireports
 ProxyPass /dcm4chee-web3 http://dcm4chee:8055/dcm4chee-web3
 ProxyPassReverse /dcm4chee-web3 http://dcm4chee:8055/dcm4chee-web3
 
+#DCM4CHEE 5
+ProxyPass /dcm4chee-arc http://dcm4chee5:8080/dcm4chee-arc
+ProxyPassReverse /dcm4chee-arc http://dcm4chee5:8080/dcm4chee-arc
+
 #Oviyam2
 ProxyPass /oviyam2 http://dcm4chee:8055/oviyam2
 ProxyPassReverse /oviyam2 http://dcm4chee:8055/oviyam2


### PR DESCRIPTION
This PR adds a proxy route for DCM4CHEE 5 services to be accessible on the `/dcm4chee-arc` subpath.