### PR TITLE
BAH-4437 | Add. Proxy rules for OHIF Viewer at /ohif path

### DIFF
--- a/resources/bahmni-proxy.conf
+++ b/resources/bahmni-proxy.conf
@@ -71,6 +71,9 @@ ProxyPassReverse /dcm4chee-web3 http://dcm4chee:8055/dcm4chee-web3
 ProxyPass /oviyam2 http://dcm4chee:8055/oviyam2
 ProxyPassReverse /oviyam2 http://dcm4chee:8055/oviyam2
 
+ProxyPass /ohif http://ohif-viewer:80/ohif
+ProxyPassReverse /ohif http://ohif-viewer:80/ohif
+
 #Atomfeed-console
 ProxyPass /atomfeed-console http://atomfeed-console:9080/atomfeed-console
 ProxyPassReverse /atomfeed-console http://atomfeed-console:9080/atomfeed-console


### PR DESCRIPTION
This PR adds proxy path rules for OHIF viewer. The service is expected to be running with name `ohif-viewer`. The service will be exposed at the base domain at `/ohif` path.