### PR TITLE
BAH-4733 changes to proxy bahmni-new as bahmni

### DIFF
--- a/resources/bahmni-proxy.conf
+++ b/resources/bahmni-proxy.conf
@@ -47,9 +47,6 @@ ProxyPassReverse /bahmni/home http://bahmni-apps-frontend/bahmni/home
 ProxyPass /bahmni/login http://bahmni-apps-frontend/bahmni/login
 ProxyPassReverse /bahmni/login http://bahmni-apps-frontend/bahmni/login
 
-ProxyPass /bahmni/v1 http://bahmni-web:8091/bahmni
-ProxyPassReverse /bahmni/v1 http://bahmni-web:8091/bahmni
-
 ProxyPass /bahmni/registration http://bahmni-apps-frontend/bahmni/registration
 ProxyPassReverse /bahmni/registration http://bahmni-apps-frontend/bahmni/registration
 
@@ -63,6 +60,10 @@ ProxyPassReverse /bahmni/manifest.json http://bahmni-apps-frontend/bahmni/manife
 #Bahmni-apps-frontend (React) — new clinical (all /bahmni/clinical/ → React; old clinical is at /bahmni/v1/clinical/)
 ProxyPass /bahmni/clinical http://bahmni-apps-frontend/bahmni/clinical
 ProxyPassReverse /bahmni/clinical http://bahmni-apps-frontend/bahmni/clinical
+
+#Bahmni Web — legacy Angular pages served under versioned path (/bahmni/v1/ → Angular)
+ProxyPass /bahmni/v1 http://bahmni-web:8091/bahmni
+ProxyPassReverse /bahmni/v1 http://bahmni-web:8091/bahmni
 
 #Bahmni Web — everything else (reports, orders, adt, programs, etc.)
 ProxyPass /bahmni http://bahmni-web:8091/bahmni
@@ -173,19 +174,6 @@ Listen 443
 
 				CacheEnable disk /bahmni
                 CacheEnable disk /openmrs/ws/rest/v1/concept
-
-                # Do not cache the React SPA shell or its entry points.
-                # The bundle JS/CSS under /bahmni/static is content-hashed so
-                # browsers can cache it safely, but the proxy must not pin a
-                # stale HTML shell or service worker.
-                CacheDisable /bahmni/index.html
-                CacheDisable /bahmni/home
-                CacheDisable /bahmni/login
-                CacheDisable /bahmni/registration
-                CacheDisable /bahmni/clinical
-                CacheDisable /bahmni/appointments
-                CacheDisable /bahmni/service-worker.js
-                CacheDisable /bahmni/manifest.json
 
 	    CacheDirLevels 5
 		CacheDirLength 3

--- a/resources/bahmni-proxy.conf
+++ b/resources/bahmni-proxy.conf
@@ -44,18 +44,8 @@ ProxyPassReverse /bahmni/static/ http://bahmni-apps-frontend/bahmni/static/
 ProxyPass /bahmni/home http://bahmni-apps-frontend/bahmni/home
 ProxyPassReverse /bahmni/home http://bahmni-apps-frontend/bahmni/home
 
-ProxyPass /bahmni/login http://bahmni-apps-frontend/bahmni/login
-ProxyPassReverse /bahmni/login http://bahmni-apps-frontend/bahmni/login
-
 ProxyPass /bahmni/registration http://bahmni-apps-frontend/bahmni/registration
 ProxyPassReverse /bahmni/registration http://bahmni-apps-frontend/bahmni/registration
-
-#Bahmni-apps-frontend (React) — PWA files
-ProxyPass /bahmni/service-worker.js http://bahmni-apps-frontend/bahmni/service-worker.js
-ProxyPassReverse /bahmni/service-worker.js http://bahmni-apps-frontend/bahmni/service-worker.js
-
-ProxyPass /bahmni/manifest.json http://bahmni-apps-frontend/bahmni/manifest.json
-ProxyPassReverse /bahmni/manifest.json http://bahmni-apps-frontend/bahmni/manifest.json
 
 #Bahmni-apps-frontend (React) — new clinical (all /bahmni/clinical/ → React; old clinical is at /bahmni/v1/clinical/)
 ProxyPass /bahmni/clinical http://bahmni-apps-frontend/bahmni/clinical

--- a/resources/bahmni-proxy.conf
+++ b/resources/bahmni-proxy.conf
@@ -36,7 +36,35 @@ ProxyPassReverse /ipd http://ipd/ipd
 ProxyPass /openmrs http://openmrs:8080/openmrs
 ProxyPassReverse /openmrs http://openmrs:8080/openmrs
 
-#Bahmni Web
+#Bahmni-apps-frontend (React) — JS/CSS assets
+ProxyPass /bahmni/static/ http://bahmni-apps-frontend/bahmni/static/
+ProxyPassReverse /bahmni/static/ http://bahmni-apps-frontend/bahmni/static/
+
+#Bahmni-apps-frontend (React) — migrated pages (covers all sub-paths including locales)
+ProxyPass /bahmni/home http://bahmni-apps-frontend/bahmni/home
+ProxyPassReverse /bahmni/home http://bahmni-apps-frontend/bahmni/home
+
+ProxyPass /bahmni/login http://bahmni-apps-frontend/bahmni/login
+ProxyPassReverse /bahmni/login http://bahmni-apps-frontend/bahmni/login
+
+ProxyPass /bahmni/v1 http://bahmni-web:8091/bahmni
+ProxyPassReverse /bahmni/v1 http://bahmni-web:8091/bahmni
+
+ProxyPass /bahmni/registration http://bahmni-apps-frontend/bahmni/registration
+ProxyPassReverse /bahmni/registration http://bahmni-apps-frontend/bahmni/registration
+
+#Bahmni-apps-frontend (React) — PWA files
+ProxyPass /bahmni/service-worker.js http://bahmni-apps-frontend/bahmni/service-worker.js
+ProxyPassReverse /bahmni/service-worker.js http://bahmni-apps-frontend/bahmni/service-worker.js
+
+ProxyPass /bahmni/manifest.json http://bahmni-apps-frontend/bahmni/manifest.json
+ProxyPassReverse /bahmni/manifest.json http://bahmni-apps-frontend/bahmni/manifest.json
+
+#Bahmni-apps-frontend (React) — new clinical (all /bahmni/clinical/ → React; old clinical is at /bahmni/v1/clinical/)
+ProxyPass /bahmni/clinical http://bahmni-apps-frontend/bahmni/clinical
+ProxyPassReverse /bahmni/clinical http://bahmni-apps-frontend/bahmni/clinical
+
+#Bahmni Web — everything else (reports, orders, adt, programs, etc.)
 ProxyPass /bahmni http://bahmni-web:8091/bahmni
 ProxyPassReverse /bahmni http://bahmni-web:8091/bahmni
 Header set X-Robots-Tag "noindex, nofollow"
@@ -83,9 +111,6 @@ ProxyPassReverse /metabase http://metabase:3000
 ProxyPass /grafana ws://grafana:3000/grafana
 ProxyPassReverse /grafana ws://grafana:3000/grafana
 
-#Bahmni-apps-frontend
-ProxyPass /bahmni-new http://bahmni-apps-frontend/bahmni-new
-ProxyPassReverse /bahmni-new http://bahmni-apps-frontend/bahmni-new
 
 LoadModule ssl_module modules/mod_ssl.so
 LoadModule cache_module modules/mod_cache.so
@@ -148,6 +173,19 @@ Listen 443
 
 				CacheEnable disk /bahmni
                 CacheEnable disk /openmrs/ws/rest/v1/concept
+
+                # Do not cache the React SPA shell or its entry points.
+                # The bundle JS/CSS under /bahmni/static is content-hashed so
+                # browsers can cache it safely, but the proxy must not pin a
+                # stale HTML shell or service worker.
+                CacheDisable /bahmni/index.html
+                CacheDisable /bahmni/home
+                CacheDisable /bahmni/login
+                CacheDisable /bahmni/registration
+                CacheDisable /bahmni/clinical
+                CacheDisable /bahmni/appointments
+                CacheDisable /bahmni/service-worker.js
+                CacheDisable /bahmni/manifest.json
 
 	    CacheDirLevels 5
 		CacheDirLength 3


### PR DESCRIPTION
# BAH-4733 Summary

Migrated the React frontend from `/bahmni-new/` to `/bahmni/`, while moving legacy Angular modules under `/bahmni/v1/`.


## New Privilege Model

Added privilege-based access for legacy Angular UX:

* `app:legacy-registration`

  * Shows “Registration (Legacy)” tile
* `app:clinical:legacyPatientTabs`

  * Shows “Active (Legacy)” and “All (Legacy)” tabs

Users without these privileges see only the new React experience.

## Major Technical Updates

* Updated proxy routing to serve React and Angular apps separately
* Converted many relative Angular URLs to absolute `/bahmni/...` paths
* Added `/bahmni/v1/...` routing for legacy modules
* React assets moved under `/bahmni/static/`
* Added session/auth guard (`SessionGate`) for React apps
* Added redirects from old Angular clinical URLs to new React URLs
* Updated login/change-password paths to legacy Angular home
* Added proxy caching support

## Repository Updates

Changes were made across 7 repositories:

1. Bahmni `bahmni-proxy`
2. `bahmni-apps-frontend`
3. `openmrs-module-bahmniapps`
4. `standard-config`
5. `openmrs-module-appointments-frontend`
6. `clinic-config`
7. `bahmni-docker`

## Outcome

* React becomes the primary frontend under `/bahmni/`
* Angular legacy modules remain accessible under `/bahmni/v1/`
* Smooth coexistence between new React UX and legacy Angular UX
* Legacy access is controlled using privileges
